### PR TITLE
Add sample Flask ASR web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
-Tentativo di creare un interfaccia web che faccia Automatic Speech Recognition in real-time usando speechmatics (API qui: https://github.com/speechmatics/speechmatics-python).
+# Demo ASR con Speechmatics
 
-Sarebbe utile avere una pagina di amministrazione dove io accendo la registrazione e vedo la trascrizione in tempo reale.
+Questo progetto dimostra come realizzare una piccola interfaccia web per la trascrizione automatica in tempo reale utilizzando la libreria [speechmatics-python](https://github.com/speechmatics/speechmatics-python).
 
-Ma ci deve essere anche una pagina per i visitatori dove tutti loro possono solo vedere quanto viene trascritto in tempo reale
+Sono previste due pagine:
+
+* **/admin** – pagina di amministrazione da cui avviare la registrazione e vedere la trascrizione.
+* **/view** – pagina pubblica in sola lettura dove i visitatori possono seguire la trascrizione in tempo reale.
+
+Il codice è un esempio semplificato: la funzione di avvio della registrazione (`start_recognition`) va collegata alla reale API di Speechmatics e alla cattura dell'audio dal microfono.
+
+## Avvio dell'applicazione
+
+1. Installare le dipendenze Python:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Impostare le credenziali Speechmatics (ad esempio tramite variabili d'ambiente) e avviare il server:
+
+```bash
+python app.py
+```
+
+L'applicazione sarà disponibile su `http://localhost:5000`. Aprire `/admin` per controllare la registrazione e `/view` per i visitatori.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+from flask import Flask, render_template
+from flask_socketio import SocketIO, emit
+
+# Placeholder import for Speechmatics real-time API
+# from speechmatics import Speechmatics
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret!'
+
+# Using simple SocketIO server
+socketio = SocketIO(app)
+
+# Store current transcript to share with new clients
+transcript_lines = []
+
+@socketio.on('start_recognition')
+def start_recognition():
+    """Placeholder function to start ASR and stream results."""
+    # In a real implementation, you would start microphone capture and
+    # send audio to Speechmatics real-time API. Here we just emit a dummy line.
+    line = 'Started recognition (demo).'
+    transcript_lines.append(line)
+    emit('transcript', line, broadcast=True)
+
+@app.route('/admin')
+def admin():
+    return render_template('admin.html')
+
+@app.route('/view')
+def view():
+    return render_template('view.html')
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SocketIO
+speechmatics-python

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin - ASR</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.socket.io/4.6.1/socket.io.min.js"></script>
+</head>
+<body>
+    <h1>Admin Control</h1>
+    <button id="start">Start Recognition</button>
+    <div id="transcript"></div>
+    <script>
+        var socket = io();
+        $('#start').click(function() {
+            socket.emit('start_recognition');
+        });
+        socket.on('transcript', function(line) {
+            $('#transcript').append('<p>' + line + '</p>');
+        });
+    </script>
+</body>
+</html>

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Live Transcript</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.socket.io/4.6.1/socket.io.min.js"></script>
+</head>
+<body>
+    <h1>Live Transcript</h1>
+    <div id="transcript"></div>
+    <script>
+        var socket = io();
+        socket.on('transcript', function(line) {
+            $('#transcript').append('<p>' + line + '</p>');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add example Flask app using SocketIO
- add basic admin and view pages
- document setup in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6845bf4cd4708331ba1e19bcc46316d9